### PR TITLE
Add setup.py to enable pip install -e .

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,28 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="dart-sam3",
+    version="0.1.0",
+    description="Detect Anything in Real Time: Real-time object detection using frontier object detection models",
+    author="mkturkcan",
+    url="https://github.com/mkturkcan/DART",
+    packages=find_packages(),
+    python_requires=">=3.11",
+    install_requires=[
+        "torch>=2.7.0",
+        "torchvision>=0.22.0",
+        "tensorrt>=10.9.0",
+        "onnx>=1.20.1",
+        "onnxsim",
+        "scipy",
+        "opencv-python",
+        "numpy",
+    ],
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.11",
+    ],
+)


### PR DESCRIPTION
Fixes #2

## Problem
The README instructs users to run `pip install -e .`, but the repository was missing a `setup.py` file, causing the installation to fail.

## Solution
Added a proper `setup.py` file with:
- Package metadata (name, version, description, author, URL)
- All required dependencies as listed in the README:
  - torch >= 2.7.0
  - torchvision >= 0.22.0
  - tensorrt >= 10.9.0
  - onnx >= 1.20.1
  - onnxsim, scipy, opencv-python, numpy
- Python 3.11+ requirement
- Proper package discovery using `find_packages()`

## Testing
Users can now successfully run:
```bash
pip install -e .
```

---
If you find this contribution helpful, consider sending a tip to:
USDT (TRC20): TJL2uq9nC6aqqGTDSUaUg8KWepSh8htrft